### PR TITLE
Fix double branches

### DIFF
--- a/src-tauri/src/git/git_branch.rs
+++ b/src-tauri/src/git/git_branch.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GitBranch {
-    name: String,
+    pub name: String,
     commit: String,
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request closes #201 

If there is a branch already in the refs files, then the packed one is invalid.

### Author

Signed-off-by: Andrei Serban - andrei.serban@brewingbytes.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `name` field in the `GitBranch` struct is now publicly accessible, allowing for easier interaction with branch names.
  
- **Improvements**
  - Enhanced logic in the `fetch_packed_refs` method to prevent duplicate branches in local and remote branch lists, improving data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->