### PR TITLE
Add ability to checkout trees

### DIFF
--- a/src-tauri/src/git/git_blob.rs
+++ b/src-tauri/src/git/git_blob.rs
@@ -4,7 +4,7 @@ use crate::errors::git_object_error::GitObjectError;
 
 use super::object::{GitObject, Header};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct GitBlob {
     size: usize,
     data: Vec<u8>,

--- a/src-tauri/src/git/git_tree.rs
+++ b/src-tauri/src/git/git_tree.rs
@@ -1,6 +1,10 @@
 use crate::errors::git_object_error::GitObjectError;
 
-use super::object::{GitObject, Header};
+use super::{
+    git_blob::GitBlob,
+    git_project::GitProject,
+    object::{GitObject, Header},
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum GitTreeMode {
@@ -137,6 +141,30 @@ impl GitTree {
             .iter()
             .filter(|entry| entry.mode != GitTreeMode::Tree)
             .collect()
+    }
+
+    /**
+     * Retrieve all blobs entries in the GitTree
+     * and from the trees in the GitTree
+     *
+     * Returns the blob entries
+     */
+    pub fn get_children_blobs(&self, project: &GitProject) -> Vec<GitBlob> {
+        let mut objects: Vec<GitBlob> = Vec::new();
+
+        let _ = self.get_trees().iter().map(|tree| {
+            let tree_obj = GitTree::from_hash(project, &tree.hash).unwrap_or_default();
+
+            let _ = tree_obj.get_blobs().iter().map(|blob| {
+                let obj = GitBlob::from_hash(project, &blob.hash);
+
+                if let Ok(obj) = obj {
+                    objects.push(obj);
+                }
+            });
+        });
+
+        objects
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request closes #51.

### Author

Signed-off-by: Andrei Serban - andrei.serban@brewingbytes.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to retrieve all blob entries from a Git tree and its subtrees, enhancing the management of Git objects within projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->