### PR TITLE
Do not load more commits if initial commit

### DIFF
--- a/src/components/Project/CommitHistory.vue
+++ b/src/components/Project/CommitHistory.vue
@@ -12,8 +12,7 @@ const height = computed(() => window.innerHeight - 64 - 24);
 async function fetchMore({ done }: { done: (status: InfiniteScrollStatus) => void }) {
 	try {
 		await useProjectStore().fetchCommitHistory(30, commits.value[commits.value.length - 1].hash);
-		return commits.value[commits.value.length - 1].parent_hashes.length > 0 ?
-			done("ok") : done("empty");
+		if(commits.value[commits.value.length - 1].parent_hashes.length > 0) done("ok"); else done("empty");
 	} catch (e) {
 		done("error");
 

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -48,7 +48,7 @@ export const useProjectStore = defineStore("project", {
 		}
 	},
 	actions: {
-		async fetchCommitHistory (length = 30, fromHash = ""): number {
+		async fetchCommitHistory (length = 30, fromHash = ""): Promise<number> {
 			let hash = "";
 
 			if (this.branch !== null && fromHash === "") {
@@ -57,8 +57,9 @@ export const useProjectStore = defineStore("project", {
 				hash = fromHash;
 			}
 
+			let history: IGitCommit[];
 			try {
-				const history: IGitCommit[] = await invoke(TauriCommands.GetCommitHistory, { project: this.selectedProject, hash, length});
+				history = await invoke(TauriCommands.GetCommitHistory, { project: this.selectedProject, hash, length});
 
 				if (fromHash === "") {
 					this.history = history;


### PR DESCRIPTION
### **User description**
### Pull Request Overview

This pull request fixes loading after initial commit.
Closes #292 

### Author

Signed-off-by: Andrei Serban - <andrei.serban@brewingbytes.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Hide loading icon when reaching initial commit

- Check parent hashes to determine if more commits exist

- Return commit count from fetch function

- Fix indentation formatting in template


___

### **Changes diagram**

```mermaid
flowchart LR
  A["fetchMore function"] --> B["Check parent_hashes"]
  B --> C["Return 'empty' if no parents"]
  B --> D["Return 'ok' if has parents"]
  C --> E["Hide loading icon"]
  D --> F["Show loading icon"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommitHistory.vue</strong><dd><code>Prevent loading icon for initial commit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Project/CommitHistory.vue

<li>Modified <code>fetchMore</code> function to check parent hashes<br> <li> Return 'empty' status when no parent commits exist<br> <li> Fixed template indentation from spaces to tabs


</details>


  </td>
  <td><a href="https://github.com/BrewingBytes/BranchWise/pull/293/files#diff-6ad65a68d6a1365ebdfa99d837be778a326ec2f7a67bcc3b1c2b395d5ee54fc1">+28/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>project.ts</strong><dd><code>Return commit count from fetch function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/stores/project.ts

<li>Added return type annotation to <code>fetchCommitHistory</code><br> <li> Return commit count or 0 on error<br> <li> Added proper error handling with return values


</details>


  </td>
  <td><a href="https://github.com/BrewingBytes/BranchWise/pull/293/files#diff-4639a7cf6a644bb9252baa30842dea3311f64a743b16c84a8c1cd43ae41aad9c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit history loading by clearly indicating when no more commits are available.
  * Enhanced feedback on commit history fetch success or failure.

* **Refactor**
  * Updated commit history retrieval logic to return the number of commits fetched or zero on error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->